### PR TITLE
Update module names away from 2.10

### DIFF
--- a/gnocchi-cli/pom.xml
+++ b/gnocchi-cli/pom.xml
@@ -4,12 +4,12 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.bdgenomics.gnocchi</groupId>
-    <artifactId>gnocchi-parent_2.10</artifactId>
+    <artifactId>gnocchi-parent_${scala.version.prefix}</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>gnocchi-cli_2.10</artifactId>
+  <artifactId>gnocchi-cli_${scala.version.prefix}</artifactId>
   <packaging>jar</packaging>
   <name>gnocchi-cli: Command line interface for managing and querying variant store</name>
 
@@ -43,7 +43,7 @@
   <dependencies>
     <dependency>
       <groupId>org.bdgenomics.gnocchi</groupId>
-      <artifactId>gnocchi-core_2.10</artifactId>
+      <artifactId>gnocchi-core_${scala.version.prefix}</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/gnocchi-core/pom.xml
+++ b/gnocchi-core/pom.xml
@@ -5,12 +5,12 @@
 
   <parent>
     <groupId>org.bdgenomics.gnocchi</groupId>
-    <artifactId>gnocchi-parent_2.10</artifactId>
+    <artifactId>gnocchi-parent_${scala.version.prefix}</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>gnocchi-core_2.10</artifactId>
+  <artifactId>gnocchi-core_${scala.version.prefix}</artifactId>
   <packaging>jar</packaging>
   <name>gnocchi-core: Core APIs and queries</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <groupId>org.bdgenomics.gnocchi</groupId>
-  <artifactId>gnocchi-parent_2.10</artifactId>
+  <artifactId>gnocchi-parent_${scala.version.prefix}</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>gnocchi: Genotype store and query engine</name>
@@ -279,7 +279,7 @@
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.gnocchi</groupId>
-        <artifactId>gnocchi-core_2.10</artifactId>
+        <artifactId>gnocchi-core_${scala.version.prefix}</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Names previously hardcoded 2.10; this generalizes the naming.