### PR TITLE
Fixing mergeGnocchiModel function

### DIFF
--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/models/GnocchiModel.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/models/GnocchiModel.scala
@@ -95,7 +95,7 @@ trait GnocchiModel[VM <: VariantModel[VM], GM <: GnocchiModel[VM, GM]] {
    *                        element corresponding to the primary phenotype being
    *                        regressed on, and the remainder corresponding to the covariates.
    */
-  //  def mergeGnocchiModel(otherModel: GnocchiModel[VM, GM]): GnocchiModel[VM, GM]
+  def mergeGnocchiModel(otherModel: GnocchiModel[VM, GM]): GnocchiModel[VM, GM]
 
   def getVariantModels: Dataset[VM] = { variantModels }
 
@@ -185,4 +185,3 @@ trait GnocchiModel[VM <: VariantModel[VM], GM <: GnocchiModel[VM, GM]] {
     metaData.save(saveTo + "/metaData")
   }
 }
-


### PR DESCRIPTION
The previous code would fail on the two tests added:

- The mergeGnocchiModel function returns object GnocchiModel, which needs to contain the mergeGnocchiModel function.
- This PR adds mergeGnocchiModel to the GnocchiModel trait so that the output of mergeGnocchiModel, can be merged with another GnocchiModel instance.