### PR TITLE
Adding support for deploying with Kelda

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can then run `gnocchi` via `gnocchi-submit`, or open a shell using `gnocchi-
 Test data is included. You can run with the test data by running:
 
 ```
-gnocchi-submit regressPhenotypes examples/testData/5snps10samples.vcf examples/testData/10samples5Phenotypes2covars.txt ADDITIVE_LINEAR ../associations -saveAsText -phenoName pheno1 -covar -covarFile examples/testData/10samples5Phenotypes2covars.txt -covarNames pheno4,pheno5 -sampleIDName SampleID
+gnocchi-submit regressPhenotypes /gnocchi/examples/testData/5snps10samples.vcf /gnocchi/examples/testData/10samples5Phenotypes2covars.txt ADDITIVE_LINEAR ../associations -saveAsText -phenoName pheno1 -covar -covarFile /gnocchi/examples/testData/10samples5Phenotypes2covars.txt -covarNames pheno4,pheno5 -sampleIDName SampleID
 ```
 
 ## Phenotype Input

--- a/kelda/Dockerfile
+++ b/kelda/Dockerfile
@@ -1,0 +1,22 @@
+# If you get an error message that looks like:
+#   Error parsing reference: "keldaio/spark as builder"
+#   is not a valid repository/tag: invalid reference format
+# It means that you're running an older version of Docker
+# that doesn't support using "as builder", and you'll
+# need to upgrade.
+FROM keldaio/spark as builder
+
+RUN apt-get update
+RUN apt-get install -y maven scala git
+
+RUN git clone https://github.com/nathanielparke/gnocchi.git -b gnocchiRefactor
+
+# On OSX with the default docker configuration this step fails because it runs
+# out of memory.  In Docker -> Preferences -> Advanced you can change the
+# memory limit to 3GB and it should work.
+RUN cd gnocchi && mvn package -DskipTests
+
+FROM keldaio/spark
+COPY --from=builder ./gnocchi gnocchi/
+
+ENV PATH /gnocchi/bin:$PATH

--- a/kelda/README.md
+++ b/kelda/README.md
@@ -1,0 +1,59 @@
+# Deploying Gnocchi to the cloud with Kelda
+
+`deploy.js` can be used to deploy the code here to a virtual machine in the
+cloud, using [Kelda](http://docs.kelda.io).  To deploy, first you'll need to
+install Kelda (you'll also need to
+[install npm](https://nodejs.org/en/download/)):
+
+```console
+$ npm install -g @kelda/install
+```
+
+Next, install the Javascript dependencies of `deploy.js`:
+
+```console
+$ npm install .
+```
+
+Finally, run the Kelda blueprint. Kelda relies on a long-running daemon to
+manage the machines that you've launched:
+
+```console
+$ nohup kelda daemon > daemon.log 2>&1 &
+```
+
+This command starts the Kelda daemon in the background (it's a long-running
+process) and saves the logs to `daemon.log`.
+
+Once the daemon is running, you can run `deploy.js`:
+
+```console
+$ kelda run ./deploy.js
+```
+
+`deploy.js` will start virtual machines on Amazon EC2. Kelda will look for
+your AWS credentials in `~/.aws/credentials` and in the environment variables
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`; if you don't already have these
+configured, check out the [Kelda docs](http://docs.kelda.io#amazon-ec2). If
+you'd like to use a different cloud provider, edit the `provider` attribute of
+the `Machine`s that are declared in `deploy.js`.
+
+`deploy.js` builds off of the
+[Kelda Spark blueprint](https://github.com/kelda/spark); refer to the
+documentation there for more about how Spark is configured and where to find the
+various Spark UIs.
+
+You can stop the machines by running `kelda stop`.
+Note that killing the Kelda daemon won't automatically kill all of the machines
+in the cluster (but if you kill the daemon before killing the machines, you can
+re-start it, and then run `kelda stop`).
+
+## Building a new version of the Gnocchi code
+
+`deploy.js` deploys a container that was built using `Dockerfile`. This
+container includes all the code needed to run Gnocchi, and will be built at
+runtime by Kelda (on the Kelda master) based on the code in the
+`gnocchiRefactor` branch of the
+[Gnocchi repository](https://github.com/nathanielparke/gnocchi).
+If you'd like to compile a different version of the code, you can edit
+`Dockerfile` to pull a different version of the code and re-run `deploy.js`.

--- a/kelda/deploy.js
+++ b/kelda/deploy.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const kelda = require('kelda');
+const spark = require('@kelda/spark');
+
+const numSparkWorkers = 16;
+
+// Initialize the virtual machines to run Spark.
+const machine = new kelda.Machine({ provider: 'Amazon', size: 'm4.xlarge' });
+
+// Create one machine for each Spark worker, plus one extra machine to run
+// the Spark master and job driver.
+const keldaWorkers = machine.replicate(numSparkWorkers + 1);
+const infra = new kelda.Infrastructure(machine, keldaWorkers);
+
+spark.setImage(new kelda.Image('gnocchi',
+  fs.readFileSync('./Dockerfile', { encoding: 'utf8' })));
+const s = new spark.Spark(numSparkWorkers,
+  { memoryMiB: spark.getWorkerMemoryMiB(machine) });
+s.exposeUIToPublic();
+s.deploy(infra);

--- a/kelda/package.json
+++ b/kelda/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "gnocchi",
+  "main": "./deploy.js",
+  "license": "MIT",
+  "dependencies": {
+    "kelda": ">=0.6",
+    "@kelda/spark": "kelda/spark"
+  }
+}


### PR DESCRIPTION
* adding a Dockerfile and a Kelda blueprint that can be
used to deploy the Gnocchi code on a cloud provider

* adding a README.md that describes how to deploy with Kelda