### PR TITLE
Change GenotypeState to counts instead of string values

### DIFF
--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LinearSiteRegression.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LinearSiteRegression.scala
@@ -102,7 +102,7 @@ trait LinearSiteRegression extends SiteRegression[LinearVariantModel, LinearAsso
                                               phenotypes: Map[String, Phenotype],
                                               allelicAssumption: String): (DenseMatrix[Double], DenseVector[Double]) = {
 
-    val validGenos = genotypes.samples.filter(genotypeState => !genotypeState.value.contains(".") && phenotypes.contains(genotypeState.sampleID))
+    val validGenos = genotypes.samples.filter(genotypeState => genotypeState.misses == 0 && phenotypes.contains(genotypeState.sampleID))
 
     val samplesGenotypes = allelicAssumption.toUpperCase match {
       case "ADDITIVE"  => validGenos.map(genotypeState => (genotypeState.sampleID, genotypeState.additive))

--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LogisticSiteRegression.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LogisticSiteRegression.scala
@@ -58,7 +58,7 @@ trait LogisticSiteRegression extends SiteRegression[LogisticVariantModel, Logist
 
     val (data, labels) = prepareDesignMatrix(phenotypes, genotypes, allelicAssumption)
 
-    val numObservations = genotypes.samples.count(x => !x.value.contains("."))
+    val numObservations = genotypes.samples.count(_.misses == 0)
 
     val maxIter = 1000
     val tolerance = 1e-6
@@ -151,7 +151,7 @@ trait LogisticSiteRegression extends SiteRegression[LogisticVariantModel, Logist
                           genotypes: CalledVariant,
                           allelicAssumption: String): (DenseMatrix[Double], DenseVector[Double]) = {
 
-    val validGenos = genotypes.samples.filter(genotypeState => !genotypeState.value.contains(".") && phenotypes.contains(genotypeState.sampleID))
+    val validGenos = genotypes.samples.filter(genotypeState => genotypeState.misses == 0 && phenotypes.contains(genotypeState.sampleID))
 
     val samplesGenotypes = allelicAssumption.toUpperCase match {
       case "ADDITIVE"  => validGenos.map(genotypeState => (genotypeState.sampleID, List(genotypeState.additive)))

--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/models/LinearGnocchiModel.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/models/LinearGnocchiModel.scala
@@ -121,10 +121,6 @@ case class LinearGnocchiModel(metaData: GnocchiModelMetaData,
           x._1.uniqueID,
           x._1.referenceAllele,
           x._1.alternateAllele,
-          x._1.qualityScore,
-          x._1.filter,
-          x._1.info,
-          x._1.format,
           x._1.samples ++ x._2.samples))
   }
 }

--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/models/LogisticGnocchiModel.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/models/LogisticGnocchiModel.scala
@@ -120,10 +120,6 @@ case class LogisticGnocchiModel(metaData: GnocchiModelMetaData,
           x._1.uniqueID,
           x._1.referenceAllele,
           x._1.alternateAllele,
-          x._1.qualityScore,
-          x._1.filter,
-          x._1.info,
-          x._1.format,
           x._1.samples ++ x._2.samples))
   }
 }

--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/primitives/genotype/GenotypeState.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/primitives/genotype/GenotypeState.scala
@@ -18,22 +18,16 @@
 package org.bdgenomics.gnocchi.primitives.genotype
 
 case class GenotypeState(sampleID: String,
-                         value: String) extends Product {
+                         refs: Int,
+                         alts: Int,
+                         misses: Int) extends Product {
+
   /**
    * @note This method removes missing values from the sum, so effectively treats them as a zero value.
    * @return a sum of the genotype states stored in the value string, with missing values removed from sum.
    */
   def toDouble: Double = {
-    toList.filter(_ != ".").map(_.toDouble).sum
-  }
-
-  /**
-   * @note This method throws away phasing information that is stored in the value string.
-   * @note This method should eventually be moved to return Doubles instead of Strings
-   * @return This method splits the value field on the two delimiters.
-   */
-  def toList: List[String] = {
-    value.split("/|\\|").toList
+    alts.toDouble
   }
 
   def additive: Double = {
@@ -46,5 +40,21 @@ case class GenotypeState(sampleID: String,
 
   def recessive: Double = {
     if (toDouble == 2.0) 1.0 else 0.0
+  }
+
+  def ploidy: Int = {
+    refs + alts + misses
+  }
+}
+
+object GenotypeState {
+  /**
+   * Static method to support legacy GenotypeState instantiation, with slash-separated integer values
+   * @return a GenotypeState with values derived from gsStr
+   */
+  def apply(sampleID: String, gsStr: String): GenotypeState = {
+    val alleleLst = gsStr.split("/|\\|")
+    val altsum = alleleLst.filter(x => x != "0" && x != ".").map(_.toDouble).sum
+    GenotypeState(sampleID, alleleLst.count(_ == "0"), alleleLst.count(_ == "1"), alleleLst.count(_ == "."))
   }
 }

--- a/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/sql/GnocchiSession.scala
+++ b/gnocchi-core/src/main/scala/org/bdgenomics/gnocchi/sql/GnocchiSession.scala
@@ -87,11 +87,7 @@ class GnocchiSession(@transient val sc: SparkContext) extends Serializable with 
     val sampleIds = genotypes.first.samples.map(x => x.sampleID)
     val separated = genotypes.select($"uniqueID" +: sampleIds.indices.map(idx => $"samples"(idx) as sampleIds(idx)): _*)
 
-    val filtered = separated.select($"uniqueID" +: sampleIds.map(sampleId =>
-      when(separated(sampleId).getField("value") === "./.", 2)
-        .when(separated(sampleId).getField("value").endsWith("."), 1)
-        .when(separated(sampleId).getField("value").startsWith("."), 1)
-        .otherwise(0) as sampleId): _*).cache()
+    val filtered = separated.select($"uniqueID" +: sampleIds.map(sampleId => separated(sampleId).getField("misses") as sampleId): _*).cache()
 
     val summed = filtered.drop("uniqueID").groupBy().sum().toDF(sampleIds: _*).select(array(sampleIds.head, sampleIds.tail: _*)).as[Array[Double]].collect.toList.head
     val count = filtered.count()
@@ -150,15 +146,7 @@ class GnocchiSession(@transient val sc: SparkContext) extends Serializable with 
           x.uniqueID,
           x.alternateAllele,
           x.referenceAllele,
-          x.qualityScore,
-          x.filter,
-          x.info,
-          x.format,
-          x.samples.map(geno => GenotypeState(geno.sampleID, geno.toList.map {
-            case "0" => "1"
-            case "1" => "0"
-            case "." => "."
-          }.mkString("/"))))
+          x.samples.map(geno => GenotypeState(geno.sampleID, geno.alts, geno.refs, geno.misses)))
       }).as[CalledVariant]
     // Note: the below .map(a => a) is a hack solution to the fact that spark cannot union two
     // datasets of the same type that have reordered columns. See issue: https://issues.apache.org/jira/browse/SPARK-21109
@@ -183,7 +171,7 @@ class GnocchiSession(@transient val sc: SparkContext) extends Serializable with 
     } else {
       val genoFile = new Path(genotypesPath)
       val fs = genoFile.getFileSystem(sc.hadoopConfiguration)
-      require(fs.exists(genoFile), s"Specified genotypes file path does not exist: ${genotypesPath}")
+      require(fs.exists(genoFile), s"Specified genotypes file path does not exist: $genotypesPath")
 
       val vcRdd = sc.loadVcf(genotypesPath)
       vcRdd.rdd.map(vc => {
@@ -193,15 +181,10 @@ class GnocchiSession(@transient val sc: SparkContext) extends Serializable with 
           if (variant.getNames.size > 0) variant.getNames.get(0) else variant.getContigName + "_" + variant.getEnd.toString,
           variant.getReferenceAllele,
           variant.getAlternateAllele,
-          "", // quality score
-          "", // filter
-          "", // info
-          "", // format
-          vc.genotypes.map(geno => GenotypeState(geno.getSampleId, geno.getAlleles.map {
-            case GenotypeAllele.REF                            => "0"
-            case GenotypeAllele.ALT | GenotypeAllele.OTHER_ALT => "1"
-            case GenotypeAllele.NO_CALL | _                    => "."
-          }.mkString("/"))).toList)
+          vc.genotypes.map(geno => GenotypeState(geno.getSampleId,
+            geno.getAlleles.count(al => al == GenotypeAllele.REF),
+            geno.getAlleles.count(al => al == GenotypeAllele.ALT || al == GenotypeAllele.OTHER_ALT),
+            geno.getAlleles.count(al => al == GenotypeAllele.NO_CALL))).toList)
       }).toDS.cache()
     }
   }

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/GnocchiFunSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/GnocchiFunSuite.scala
@@ -66,7 +66,7 @@ trait GnocchiFunSuite extends SparkFunSuite {
     val form = if (format.isEmpty) "." else format.get
     val sam = if (samples.isEmpty) createSampleGenotypeStates(num = 50) else samples.get
 
-    CalledVariant(chrom, pos, uid, ref, alt, qs, fil, inf, form, sam)
+    CalledVariant(chrom, pos, uid, ref, alt, sam)
   }
 
   def createSamplePhenotype(calledVariant: Option[CalledVariant] = None,

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LinearSiteRegressionSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LinearSiteRegressionSuite.scala
@@ -65,7 +65,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -102,7 +102,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -139,7 +139,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -176,7 +176,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -285,7 +285,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
     // use additiveLinearAssociation to regress on PIQ data
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -315,7 +315,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
   sparkTest("LinearSiteRegression.applyToSite should break on a singular matrix") {
     val genotypeStates = List(GenotypeState("sample1", "0"))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = Map("sample1" -> Phenotype("sample1", "pheno1", 1))
 
@@ -326,7 +326,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
   sparkTest("LinearSiteRegression.applyToSite should break when there is not overlap between sampleIDs in phenotypes and CalledVariant objects.") {
     val genotypeStates = List(GenotypeState("sample1", "0"))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = Map("sample2" -> Phenotype("sample2", "pheno1", 1))
 
@@ -344,7 +344,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
   }
 
   // LinearSiteRegression.prepareDesignMatrix tests
-  sparkTest("LinearSiteRegression.prepareDesignMatrix should produce a matrix with missing values filtered out.") {
+  ignore("LinearSiteRegression.prepareDesignMatrix should produce a matrix with missing values filtered out.") {
     val observations = new Array[(String, Array[Double])](10)
     observations(0) = ("1", Array[Double](1))
     observations(1) = ("2", Array[Double](2))
@@ -359,7 +359,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -387,7 +387,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -414,7 +414,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList
@@ -441,7 +441,7 @@ class LinearSiteRegressionSuite extends GnocchiFunSuite {
 
     val (genotypes, phenotypes) = observations.unzip
     val genotypeStates = genotypes.toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
 
     val phenoMap = phenotypes
       .toList

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LogisticSiteRegressionSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/algorithms/siteregression/LogisticSiteRegressionSuite.scala
@@ -170,7 +170,7 @@ class LogisticSiteRegressionSuite extends GnocchiFunSuite {
 
     val (data, label) = LogisticSiteRegression.prepareDesignMatrix(phenos, cv, "ADDITIVE")
 
-    val genos = DenseVector(cv.samples.filter(!_.toList.contains(".")).map(_.toDouble): _*)
+    val genos = DenseVector(cv.samples.filter(_.misses == 0).map(_.toDouble): _*)
     assert(data(::, 1) == genos, "LogisticSiteRegression.prepareDesignMatrix places genos in the wrong place")
   }
 
@@ -182,7 +182,7 @@ class LogisticSiteRegressionSuite extends GnocchiFunSuite {
     val (data, label) = LogisticSiteRegression.prepareDesignMatrix(phenos, cv, "ADDITIVE")
 
     val covs = data(::, 2 to -1)
-    val rows = phenos.filter(x => cv.samples.filter(!_.toList.contains(".")).map(_.sampleID).contains(x._1))
+    val rows = phenos.filter(x => cv.samples.filter(_.misses == 0).map(_.sampleID).contains(x._1))
       .map(_._2.covariates)
       .toList
     val otherCovs = DenseMatrix(rows: _*)

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/models/LinearGnocchiModelSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/models/LinearGnocchiModelSuite.scala
@@ -25,7 +25,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observations(2) = (10, 7)
 
     val genotypeStates = observations.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
     val cvDataset = mutable.MutableList[CalledVariant](cv).toDS()
 
     val phenoMap = observations.map(_._2)
@@ -42,7 +42,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observationsSecond(2) = (32, 2)
 
     val genotypeStatesSecond = observationsSecond.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetSecond = mutable.MutableList[CalledVariant](cvSecond).toDS()
 
     val linearGnocchiModelSecond = LinearGnocchiModelFactory.apply(cvDatasetSecond, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))
@@ -70,7 +70,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observations(2) = (10, 7)
 
     val genotypeStates = observations.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
     val cvDataset = mutable.MutableList[CalledVariant](cv).toDS()
 
     val phenoMap = observations.map(_._2)
@@ -88,7 +88,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observationsSecond(2) = (32, 2)
 
     val genotypeStatesSecond = observationsSecond.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetSecond = mutable.MutableList[CalledVariant](cvSecond).toDS()
 
     val linearGnocchiModelSecond = LinearGnocchiModelFactory.apply(cvDatasetSecond, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))
@@ -100,7 +100,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observationsThird(2) = (34, 1)
 
     val genotypeStatesThird = observationsThird.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvThird = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesThird)
+    val cvThird = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesThird)
     val cvDatasetThird = mutable.MutableList[CalledVariant](cvThird).toDS()
 
     val linearGnocchiModelThird = LinearGnocchiModelFactory.apply(cvDatasetThird, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))
@@ -122,7 +122,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     assert(finalMergedModel.metaData == newMetadata)
   }
 
-  sparkTest("LinearGnocchiModel.mergeQCVariants correct combines variant samples") {
+  ignore("LinearGnocchiModel.mergeQCVariants correct combines variant samples") {
     val spark = SparkSession.builder().master("local").getOrCreate()
     import spark.implicits._
 
@@ -133,7 +133,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observations(2) = (13, 7)
 
     val genotypeStates = observations.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
     val cvDataset = mutable.MutableList[CalledVariant](cv).toDS()
 
     val phenoMap = observations.map(_._2)
@@ -151,7 +151,7 @@ class LinearGnocchiModelSuite extends GnocchiFunSuite {
     observationsSecond(2) = (32, 2)
 
     val genotypeStatesSecond = observationsSecond.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetSecond = mutable.MutableList[CalledVariant](cvSecond).toDS()
 
     val linearGnocchiModelSecond = LinearGnocchiModelFactory.apply(cvDatasetSecond, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/models/LogisticGnocchiModelSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/models/LogisticGnocchiModelSuite.scala
@@ -25,7 +25,7 @@ class LogisticGnocchiModelSuite extends GnocchiFunSuite {
     observations(2) = (13, 7)
 
     val genotypeStates = observations.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
     val cvDataset = mutable.MutableList[CalledVariant](cv).toDS()
 
     val phenoMap = observations.map(_._2)
@@ -42,7 +42,7 @@ class LogisticGnocchiModelSuite extends GnocchiFunSuite {
     observationsSecond(2) = (32, 2)
 
     val genotypeStatesSecond = observationsSecond.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetSecond = mutable.MutableList[CalledVariant](cvSecond).toDS()
 
     val logisticGnocchiModelSecond = LogisticGnocchiModelFactory.apply(cvDatasetSecond, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))
@@ -70,7 +70,7 @@ class LogisticGnocchiModelSuite extends GnocchiFunSuite {
     observations(2) = (13, 7)
 
     val genotypeStates = observations.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cv = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStates)
+    val cv = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStates)
     val cvDataset = mutable.MutableList[CalledVariant](cv).toDS()
 
     val phenoMap = observations.map(_._2)
@@ -88,7 +88,7 @@ class LogisticGnocchiModelSuite extends GnocchiFunSuite {
     observationsSecond(2) = (32, 2)
 
     val genotypeStatesSecond = observationsSecond.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetSecond = mutable.MutableList[CalledVariant](cvSecond).toDS()
 
     val logisticGnocchiModelSecond = LogisticGnocchiModelFactory.apply(cvDatasetSecond, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))
@@ -100,7 +100,7 @@ class LogisticGnocchiModelSuite extends GnocchiFunSuite {
     observationsThird(2) = (34, 1)
 
     val genotypeStatesThird = observationsThird.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvThird = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvThird = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetThird = mutable.MutableList[CalledVariant](cvThird).toDS()
 
     val logisticGnocchiModelThird = LogisticGnocchiModelFactory.apply(cvDatasetThird, sc.broadcast(phenoMap), Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))
@@ -153,7 +153,7 @@ class LogisticGnocchiModelSuite extends GnocchiFunSuite {
     observationsSecond(2) = (32, 2)
 
     val genotypeStatesSecond = observationsSecond.map(_._1).toList.zipWithIndex.map(item => GenotypeState(item._2.toString, item._1.toString))
-    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", "", "", "", "", genotypeStatesSecond)
+    val cvSecond = CalledVariant(1, 1, "rs123456", "A", "C", genotypeStatesSecond)
     val cvDatasetSecond = mutable.MutableList[CalledVariant](cvSecond).toDS()
 
     val logisticGnocchiModelSecond = LogisticGnocchiModelFactory.apply(cvDataset, phenos, Option.apply(List[String]("pheno1")), Option.apply(List[String]("rs123456").toSet))

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/primitives/genotype/GenotypeStateSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/primitives/genotype/GenotypeStateSuite.scala
@@ -37,17 +37,6 @@ class GenotypeStateSuite extends GnocchiFunSuite {
     assert(gs.toDouble == 1.0, "GenotypeState.toDouble does not correctly count the number of alternate alleles when there are missing values.")
   }
 
-  // to List tests
-  sparkTest("GenotypeState.toList should split the genotype state into a list of genotype values: pipe delimiter.") {
-    val gs = GenotypeState("1234", "1|0")
-    assert(gs.toList == List[String]("1", "0"), "GenotypeState.toList does not correctly split the genotypes on pipe delimiter.")
-  }
-
-  sparkTest("GenotypeState.toList should split the genotype state into a list of genotype values: forward slash delimiter.") {
-    val gs = GenotypeState("1234", "1/0")
-    assert(gs.toList == List[String]("1", "0"), "GenotypeState.toList does not correctly split the genotypes on forward slash delimiter.")
-  }
-
   // Allelic Assumption tests
 
   sparkTest("GenotypeState.dominant should map 0.0 to 0.0 and everything else to 1.0") {

--- a/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/sql/GnocchiSessionSuite.scala
+++ b/gnocchi-core/src/test/scala/org/bdgenomics/gnocchi/sql/GnocchiSessionSuite.scala
@@ -190,12 +190,13 @@ class GnocchiSessionSuite extends GnocchiFunSuite {
   // filter samples tests
 
   private def makeGenotypeState(id: String, gs: String): GenotypeState = {
-    GenotypeState(id, gs)
+    val alleleLst = gs.split("/")
+    GenotypeState(id, alleleLst.count(_ == "0"), alleleLst.count(_ == "1"), alleleLst.count(_ == "."))
   }
 
   private def makeCalledVariant(uid: Int, sampleIds: List[String], genotypeStates: List[String]): CalledVariant = {
     val samples = sampleIds.zip(genotypeStates).map(idGs => makeGenotypeState(idGs._1, idGs._2))
-    CalledVariant(1, 1234, uid.toString(), "A", "G", "60", "PASS", ".", "GT", samples)
+    CalledVariant(1, 1234, uid.toString(), "A", "G", samples)
   }
 
   private def makeCalledVariantDS(variants: List[CalledVariant]): Dataset[CalledVariant] = {
@@ -446,16 +447,8 @@ class GnocchiSessionSuite extends GnocchiFunSuite {
     assert(recoded.uniqueID == sampleVar.uniqueID, "sc.recodeMajorAllele incorrectly changed the uniqueID value of variants to be recoded.")
     assert(recoded.alternateAllele == sampleVar.referenceAllele, "sc.recodeMajorAllele incorrectly did not change the alternate allele value of variants to be recoded.")
     assert(recoded.referenceAllele == sampleVar.alternateAllele, "sc.recodeMajorAllele incorrectly did not change the reference allele value of variants to be recoded.")
-    assert(recoded.qualityScore == sampleVar.qualityScore, "sc.recodeMajorAllele incorrectly changed the quality score value of variants to be recoded.")
-    assert(recoded.filter == sampleVar.filter, "sc.recodeMajorAllele incorrectly changed the filter value of variants to be recoded.")
-    assert(recoded.info == sampleVar.info, "sc.recodeMajorAllele incorrectly changed the info value of variants to be recoded.")
-    assert(recoded.format == sampleVar.format, "sc.recodeMajorAllele incorrectly changed the format value of variants to be recoded.")
 
-    val recodedSamples = sampleVar.samples.map(geno => GenotypeState(geno.sampleID, geno.toList.map {
-      case "0" => "1"
-      case "1" => "0"
-      case "." => "."
-    }.mkString("/")))
+    val recodedSamples = sampleVar.samples.map(geno => GenotypeState(geno.sampleID, geno.alts, geno.refs, geno.misses))
 
     assert(recodedSamples == recoded.samples, "sc.recodeMajorAllele incorrectly recoded the alleles in the input variant.")
   }
@@ -471,16 +464,8 @@ class GnocchiSessionSuite extends GnocchiFunSuite {
     assert(recoded.uniqueID == sampleVar.uniqueID, "sc.recodeMajorAllele incorrectly changed the uniqueID value of variants to be recoded.")
     assert(recoded.alternateAllele == sampleVar.referenceAllele, "sc.recodeMajorAllele incorrectly did not change the alternate allele value of variants to be recoded.")
     assert(recoded.referenceAllele == sampleVar.alternateAllele, "sc.recodeMajorAllele incorrectly did not change the reference allele value of variants to be recoded.")
-    assert(recoded.qualityScore == sampleVar.qualityScore, "sc.recodeMajorAllele incorrectly changed the quality score value of variants to be recoded.")
-    assert(recoded.filter == sampleVar.filter, "sc.recodeMajorAllele incorrectly changed the filter value of variants to be recoded.")
-    assert(recoded.info == sampleVar.info, "sc.recodeMajorAllele incorrectly changed the info value of variants to be recoded.")
-    assert(recoded.format == sampleVar.format, "sc.recodeMajorAllele incorrectly changed the format value of variants to be recoded.")
 
-    val recodedSamples = sampleVar.samples.map(geno => GenotypeState(geno.sampleID, geno.toList.map {
-      case "0" => "1"
-      case "1" => "0"
-      case "." => "."
-    }.mkString("/")))
+    val recodedSamples = sampleVar.samples.map(geno => GenotypeState(geno.sampleID, geno.alts, geno.refs, geno.misses))
 
     assert(recodedSamples == recoded.samples, "sc.recodeMajorAllele incorrectly recoded the alleles in the input variant.")
   }
@@ -496,10 +481,6 @@ class GnocchiSessionSuite extends GnocchiFunSuite {
     assert(recoded.uniqueID == sampleVar.uniqueID, "sc.recodeMajorAllele incorrectly changed the uniqueID value of variants to be recoded.")
     assert(recoded.referenceAllele == sampleVar.referenceAllele, "sc.recodeMajorAllele incorrectly changed the reference allele value of variants to be recoded.")
     assert(recoded.alternateAllele == sampleVar.alternateAllele, "sc.recodeMajorAllele incorrectly changed the alternate allele value of variants to be recoded.")
-    assert(recoded.qualityScore == sampleVar.qualityScore, "sc.recodeMajorAllele incorrectly changed the quality score value of variants to be recoded.")
-    assert(recoded.filter == sampleVar.filter, "sc.recodeMajorAllele incorrectly changed the filter value of variants to be recoded.")
-    assert(recoded.info == sampleVar.info, "sc.recodeMajorAllele incorrectly changed the info value of variants to be recoded.")
-    assert(recoded.format == sampleVar.format, "sc.recodeMajorAllele incorrectly changed the format value of variants to be recoded.")
 
     assert(sampleVar.samples == recoded.samples, "sc.recodeMajorAllele incorrectly recoded the alleles in the input variant.")
   }
@@ -515,10 +496,6 @@ class GnocchiSessionSuite extends GnocchiFunSuite {
     assert(recoded.uniqueID == sampleVar.uniqueID, "sc.recodeMajorAllele incorrectly changed the uniqueID value of variants to be recoded.")
     assert(recoded.referenceAllele == sampleVar.referenceAllele, "sc.recodeMajorAllele incorrectly changed the reference allele value of variants to be recoded.")
     assert(recoded.alternateAllele == sampleVar.alternateAllele, "sc.recodeMajorAllele incorrectly changed the alternate allele value of variants to be recoded.")
-    assert(recoded.qualityScore == sampleVar.qualityScore, "sc.recodeMajorAllele incorrectly changed the quality score value of variants to be recoded.")
-    assert(recoded.filter == sampleVar.filter, "sc.recodeMajorAllele incorrectly changed the filter value of variants to be recoded.")
-    assert(recoded.info == sampleVar.info, "sc.recodeMajorAllele incorrectly changed the info value of variants to be recoded.")
-    assert(recoded.format == sampleVar.format, "sc.recodeMajorAllele incorrectly changed the format value of variants to be recoded.")
 
     assert(sampleVar.samples == recoded.samples, "sc.recodeMajorAllele incorrectly recoded the alleles in the input variant.")
   }
@@ -534,10 +511,6 @@ class GnocchiSessionSuite extends GnocchiFunSuite {
     assert(recoded.uniqueID == sampleVar.uniqueID, "sc.recodeMajorAllele incorrectly changed the uniqueID value of variants to be recoded.")
     assert(recoded.referenceAllele == sampleVar.referenceAllele, "sc.recodeMajorAllele incorrectly changed the reference allele value of variants to be recoded.")
     assert(recoded.alternateAllele == sampleVar.alternateAllele, "sc.recodeMajorAllele incorrectly changed the alternate allele value of variants to be recoded.")
-    assert(recoded.qualityScore == sampleVar.qualityScore, "sc.recodeMajorAllele incorrectly changed the quality score value of variants to be recoded.")
-    assert(recoded.filter == sampleVar.filter, "sc.recodeMajorAllele incorrectly changed the filter value of variants to be recoded.")
-    assert(recoded.info == sampleVar.info, "sc.recodeMajorAllele incorrectly changed the info value of variants to be recoded.")
-    assert(recoded.format == sampleVar.format, "sc.recodeMajorAllele incorrectly changed the format value of variants to be recoded.")
 
     assert(sampleVar.samples == recoded.samples, "sc.recodeMajorAllele incorrectly recoded the alleles in the input variant.")
   }


### PR DESCRIPTION
The newly ignored tests all regard storing real values instead of counts in GenotypeState. As we had it before, you could store non 1 or 0 values in GenotypeState, but since we count 0's and 1's (technically all non-0's) instead, we can't store values used for a lot of the tests.